### PR TITLE
Improved general email validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "beelab/recaptcha2-bundle": "^1.0",
         "bmatzner/fontawesome-bundle": "^4.6",
         "ramsey/uuid": "^3.5",
-        "qandidate/stack-request-id": "dev-ramsey-uuid-v3"
+        "qandidate/stack-request-id": "dev-ramsey-uuid-v3",
+        "egulias/email-validator": "~1.2"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "aafeb5fe4471f0182a56c0ed1118233f",
-    "content-hash": "15e2e7ac241cc65e189d013afcde47dd",
+    "hash": "fee10d7a9fbcb629bca187af8f14d503",
+    "content-hash": "39c1e86bbcd4017b59b8732e0a2a9240",
     "packages": [
         {
             "name": "beelab/recaptcha2-bundle",
@@ -1071,6 +1071,58 @@
                 "orm"
             ],
             "time": "2015-08-31 13:19:01"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "1.2.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "b8bb147f46cc9790326ce2440a13be06cc5a63bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/b8bb147f46cc9790326ce2440a13be06cc5a63bb",
+                "reference": "b8bb147f46cc9790326ce2440a13be06cc5a63bb",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.0.1",
+                "php": ">= 5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Egulias\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2016-07-03 21:52:18"
         },
         {
             "name": "facebook/php-sdk",

--- a/src/LoginCidadao/CoreBundle/Entity/Person.php
+++ b/src/LoginCidadao/CoreBundle/Entity/Person.php
@@ -118,7 +118,7 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
      * @JMS\Expose
      * @JMS\Groups({"email"})
      * @JMS\Since("1.0")
-     * @Assert\Email(groups={"Registration", "ResetPassword", "ChangePassword", "LoginCidadaoRegistration", "LoginCidadaoEmailForm"})
+     * @Assert\Email(strict=true, groups={"Registration", "ResetPassword", "ChangePassword", "LoginCidadaoRegistration", "LoginCidadaoEmailForm"})
      */
     protected $email;
 

--- a/src/LoginCidadao/CoreBundle/Model/SupportMessage.php
+++ b/src/LoginCidadao/CoreBundle/Model/SupportMessage.php
@@ -34,7 +34,7 @@ class SupportMessage
      * @var string
      *
      * @Assert\NotBlank
-     * @Assert\Email
+     * @Assert\Email(strict=true)
      * @Assert\Length(
      *     max="255",
      *     maxMessage="person.validation.email.length.max"


### PR DESCRIPTION
Enabled `strict` validation for email addresses since Symfony's regular expression is not RFC compliant.