### PR TITLE
Changed scope.phone_number translation

### DIFF
--- a/src/LoginCidadao/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/messages.en.yml
@@ -15,7 +15,7 @@ scope.city: City
 scope.badges: Badges
 scope.picture: Picture
 scope.public_profile: Public Profile
-scope.phone_number: Phone Number
+scope.phone_number: Mobile
 scope_details.public_profile: Your public profile contains your first name, age range and your certificates (badges).
 'Citizen''s Login': 'Citizen''s Login'
 'Need help?': 'Need help?'

--- a/src/LoginCidadao/CoreBundle/Resources/translations/messages.pt_BR.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/messages.pt_BR.yml
@@ -15,7 +15,7 @@ scope.city: Cidade
 scope.badges: Medalhas
 scope.picture: Foto
 scope.public_profile: 'Perfil Público'
-scope.phone_number: Telefone
+scope.phone_number: Celular
 scope_details.public_profile: Primeiro nome e faixa etária
 'Revoke Access': 'Revogar Acesso'
 'Visit Site': 'Visitar Site'


### PR DESCRIPTION
The scope `phone_number` is a generic phone number, but in `login-cidadao` we implemented it as a mobile number, since it can be verified. For this reason we should present this scope as "Mobile" instead of a more generic "Phone number".