### PR TITLE
added password NotBlank check. fixes PROCERGS#643

### DIFF
--- a/src/LoginCidadao/CoreBundle/Entity/Person.php
+++ b/src/LoginCidadao/CoreBundle/Entity/Person.php
@@ -112,6 +112,7 @@ class Person extends BaseUser implements PersonInterface, TwoFactorInterface, Ba
      *     minMessage="person.validation.password.length.min",
      *     groups={"Registration", "ResetPassword", "ChangePassword", "LoginCidadaoRegistration"}
      * )
+     * @Assert\NotBlank(message="person.validation.password.blank", groups={"Registration", "ResetPassword", "ChangePassword", "LoginCidadaoRegistration"})
      */
     protected $plainPassword;
 

--- a/src/LoginCidadao/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/validators.en.yml
@@ -19,6 +19,7 @@ person.validation:
             max: The password must have at most {{ limit }} characters
         missingNumbers: Your password must include at least one number.
         missingLetters: Your password must include at least one letter.
+        blank: You have to create a password.
     cpf.already_used: This CPF is already in use.
     mobile:
         9thDigit: Brazilian cellphones need the 9th digit

--- a/src/LoginCidadao/CoreBundle/Resources/translations/validators.pt_BR.yml
+++ b/src/LoginCidadao/CoreBundle/Resources/translations/validators.pt_BR.yml
@@ -23,6 +23,7 @@ person.validation:
             max: A senha deve ter, no máximo, {{ limit }} caracteres
         missingNumbers: Sua senha precisa ter ao menos um número.
         missingLetters: Sua senha precisa ter ao menos uma letra.
+        blank: Você precisa criar uma senha.
     cpf.already_used: Esse CPF já está cadastrado.
     mobile:
         9thDigit: Os celulares no Brasil precisam do 9º dígito


### PR DESCRIPTION
If the user's browser did not support the `required` attribute the form would get posted without an error. Added constraint to fix it.