### PR TITLE
New definition of "empty" for the GetTasksEvent

### DIFF
--- a/src/LoginCidadao/TaskStackBundle/Event/GetTasksEvent.php
+++ b/src/LoginCidadao/TaskStackBundle/Event/GetTasksEvent.php
@@ -10,6 +10,7 @@
 
 namespace LoginCidadao\TaskStackBundle\Event;
 
+use LoginCidadao\TaskStackBundle\Model\IntentTask;
 use LoginCidadao\TaskStackBundle\Model\TaskInterface;
 use LoginCidadao\TaskStackBundle\Service\TaskStackManagerInterface;
 use Symfony\Component\EventDispatcher\Event;
@@ -46,12 +47,27 @@ class GetTasksEvent extends Event
     }
 
     /**
+     * Only add the task if the Stack is empty.
+     *
+     * If the Stack contains only one IntentTask task, then the Stack will be considered empty.
+     *
      * @param TaskInterface $task
      * @return $this
      */
     public function addTaskIfStackEmpty(TaskInterface $task)
     {
-        if ($this->stackManager->countTasks() === 0) {
+        $count = $this->stackManager->countTasks();
+
+        if ($count >= 2) {
+            return $this;
+        }
+
+        if ($count === 0) {
+            $this->addTask($task);
+        }
+
+        $currentTask = $this->stackManager->getCurrentTask();
+        if ($count === 1 && $currentTask instanceof IntentTask) {
             $this->addTask($task);
         }
 

--- a/src/LoginCidadao/TaskStackBundle/Tests/Service/TaskStackManagerTest.php
+++ b/src/LoginCidadao/TaskStackBundle/Tests/Service/TaskStackManagerTest.php
@@ -55,10 +55,10 @@ class TaskStackManagerTest extends \PHPUnit_Framework_TestCase
 
     private function getStackManager($params = [])
     {
-        $session = $params['session'] ?: $this->getSession();
-        $tokenStorage = $params['token_storage'] ?: $this->getTokenStorage();
-        $router = $params['router'] ?: $this->getRouter();
-        $dispatcher = $params['dispatcher'] ?: $this->getDispatcher();
+        $session = isset($params['session']) ? $params['session'] : $this->getSession();
+        $tokenStorage = isset($params['token_storage']) ? $params['token_storage'] : $this->getTokenStorage();
+        $router = isset($params['router']) ? $params['router'] : $this->getRouter();
+        $dispatcher = isset($params['dispatcher']) ? $params['dispatcher'] : $this->getDispatcher();
 
         $manager = new TaskStackManager(
             $session, $tokenStorage, $router, $dispatcher
@@ -265,5 +265,19 @@ class TaskStackManagerTest extends \PHPUnit_Framework_TestCase
         $manager->addNotSkippedTaskOnce($task3);
 
         $this->assertEquals($task2, $manager->getNextTask());
+    }
+
+    public function testCountTasks()
+    {
+        $task1 = $this->getTask('task1');
+        $task2 = $this->getTask('task2');
+        $task3 = $this->getTask('task3');
+
+        $manager = $this->getStackManager();
+        $manager->addNotSkippedTaskOnce($task1);
+        $manager->addNotSkippedTaskOnce($task2);
+        $manager->addNotSkippedTaskOnce($task3);
+
+        $this->assertEquals(3, $manager->countTasks());
     }
 }


### PR DESCRIPTION
`GetTasksEvent` now considers the Stack empty if there is only an `IntentTask` in it.

This is done to avoid the following:

1. Non-authenticated user tries to access resource X
2. X is Stacked as an `IntentTask`
3. User logs in
4. `addTaskIfStackEmpty` will not add needed tasks
5. `IntentTask` is consumed, but now `addTaskIfStackEmpty` will add the needed task that was not added before
6. User enters a Task an doesn't even see resource X

Fixes PROCERGS#679