### PR TITLE
Fixed SentVerification query

### DIFF
--- a/src/LoginCidadao/PhoneVerificationBundle/Controller/VerificationController.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Controller/VerificationController.php
@@ -103,7 +103,7 @@ class VerificationController extends Controller
         $verification = $phoneVerificationService->getPendingPhoneVerificationById($id, $this->getUser());
 
         try {
-            $phoneVerificationService->resendVerificationCode($verification);
+            $phoneVerificationService->sendVerificationCode($verification);
 
             $result = ['type' => 'success', 'message' => 'tasks.verify_phone.resend.success'];
         } catch (TooManyRequestsHttpException $e) {

--- a/src/LoginCidadao/PhoneVerificationBundle/Entity/SentVerificationRepository.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Entity/SentVerificationRepository.php
@@ -12,6 +12,7 @@ namespace LoginCidadao\PhoneVerificationBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
 use LoginCidadao\PhoneVerificationBundle\Model\PhoneVerificationInterface;
+use Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType;
 
 /**
  * @codeCoverageIgnore
@@ -23,7 +24,7 @@ class SentVerificationRepository extends EntityRepository
         $query = $this->createQueryBuilder('s')
             ->where('s.phone = :phone')
             ->orderBy('s.sentAt', 'DESC')
-            ->setParameter('phone', $phoneVerification->getPhone());
+            ->setParameter('phone', $phoneVerification->getPhone(), PhoneNumberType::NAME);
 
         // Filter only SentVerification that belong to this PhoneVerification
         if ($phoneVerification->isVerified()) {

--- a/src/LoginCidadao/PhoneVerificationBundle/Event/ProfileEditSubscriber.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Event/ProfileEditSubscriber.php
@@ -67,7 +67,7 @@ class ProfileEditSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($this->originalPhone !== $person->getMobile()) {
+        if ($this->originalPhone != $person->getMobile()) {
             $phoneChangedEvent = new PhoneChangedEvent($person, $this->originalPhone);
             $dispatcher->dispatch(PhoneVerificationEvents::PHONE_CHANGED, $phoneChangedEvent);
         }

--- a/src/LoginCidadao/PhoneVerificationBundle/Event/TaskSubscriber.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Event/TaskSubscriber.php
@@ -78,9 +78,7 @@ class TaskSubscriber implements EventSubscriberInterface
         if ($pendingVerification && !$lastSentVerification) {
             try {
                 if ($user->getMobile() != $pendingVerification->getPhone()) {
-                    // Remove orphan verifications
-                    $this->phoneVerificationService->removePhoneVerification($pendingVerification);
-
+                    // Orphan verification. Do not add a task
                     return;
                 }
                 $this->phoneVerificationService->sendVerificationCode($pendingVerification);

--- a/src/LoginCidadao/PhoneVerificationBundle/Service/PhoneVerificationServiceInterface.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Service/PhoneVerificationServiceInterface.php
@@ -104,13 +104,6 @@ interface PhoneVerificationServiceInterface
     public function sendVerificationCode(PhoneVerificationInterface $phoneVerification);
 
     /**
-     * @param PhoneVerificationInterface $phoneVerification
-     * @throws TooManyRequestsHttpException
-     * @throws VerificationNotSentException
-     */
-    public function resendVerificationCode(PhoneVerificationInterface $phoneVerification);
-
-    /**
      * @param SentVerificationInterface $sentVerification
      * @return SentVerification
      */

--- a/src/LoginCidadao/PhoneVerificationBundle/Tests/Service/PhoneVerificationServiceTest.php
+++ b/src/LoginCidadao/PhoneVerificationBundle/Tests/Service/PhoneVerificationServiceTest.php
@@ -367,7 +367,7 @@ class PhoneVerificationServiceTest extends \PHPUnit_Framework_TestCase
             );
 
         $service = $this->getService(compact('dispatcher'));
-        $service->resendVerificationCode($phoneVerification);
+        $service->sendVerificationCode($phoneVerification);
     }
 
     public function testResendVerificationCodeFailure()
@@ -386,7 +386,7 @@ class PhoneVerificationServiceTest extends \PHPUnit_Framework_TestCase
         $options->expects($this->once())->method('getSmsResendTimeout')->willReturn('+5 minutes');
 
         $service = $this->getService(['sent_verification_repository' => $repository, 'options' => $options]);
-        $service->resendVerificationCode($phoneVerification);
+        $service->sendVerificationCode($phoneVerification);
     }
 
     public function testRegisterVerificationSent()


### PR DESCRIPTION
The `SentVerificationRepository::getLastVerificationSent()` method was not working properly due to a wrong serialization of the `PhoneNumber` object.

Fixed PROCERGS#683 by specifying the type.