### PR TITLE
Fixed ID Token validation

### DIFF
--- a/src/LoginCidadao/OpenIDBundle/Controller/SessionManagementController.php
+++ b/src/LoginCidadao/OpenIDBundle/Controller/SessionManagementController.php
@@ -277,7 +277,7 @@ class SessionManagementController extends Controller
 
         $postLogoutUri = ClientMetadata::canonicalizeUri($postLogoutUri);
 
-        if ($idToken === null) {
+        if (!$idToken) {
             return count($this->findClientByPostLogoutRedirectUri($postLogoutUri)) > 0;
         }
 


### PR DESCRIPTION
An unnecessary exception was being thrown at the RP-Initiated Logout due to a wrong check of the ID Token.

Fixes PROCERGS#687