### PR TITLE
Configurable Google Analytics

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,6 +40,7 @@ twig:
         third_party_login: %third_party_login%
         password_hint: "@password_hint"
         intl_tel_input_preferred_countries: ["br"]
+        google_analytics_trackingId: "%google_analytics_trackingId%"
 
 # Assetic Configuration
 assetic:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -152,3 +152,7 @@ parameters:
     # When true, during the authorization process, the user will only be prompted to fill in missing information
     # if it's a new authorization
     pre_authorization.complete_information_task.skip_if_authorized: true
+
+    # The ID provided by Google Analytics to configure tracking
+    # You can override the LoginCidadaoCoreBundle::analytics.html.twig entirely if you don't want the default settings
+    google_analytics_trackingId: YourGoogleAnalyticsId

--- a/app/config/parameters.yml.vagrant
+++ b/app/config/parameters.yml.vagrant
@@ -116,3 +116,7 @@ parameters:
     # When true, during the authorization process, the user will only be prompted to fill in missing information
     # if it's a new authorization
     pre_authorization.complete_information_task.skip_if_authorized: true
+
+    # The ID provided by Google Analytics to configure tracking
+    # You can override the LoginCidadaoCoreBundle::analytics.html.twig entirely if you don't want the default settings
+    google_analytics_trackingId: YourGoogleAnalyticsId

--- a/src/LoginCidadao/CoreBundle/Resources/views/analytics.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/analytics.html.twig
@@ -1,0 +1,9 @@
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ google_analytics_trackingId }}', 'auto');
+    ga('send', 'pageview');
+</script>

--- a/src/LoginCidadao/CoreBundle/Resources/views/base.html.twig
+++ b/src/LoginCidadao/CoreBundle/Resources/views/base.html.twig
@@ -78,14 +78,5 @@ window.onload=function(){
 }
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-46166474-3', 'rs.gov.br');
-  ga('send', 'pageview');
-
-</script>
+{{ include("LoginCidadaoCoreBundle::analytics.html.twig") }}
 {% endblock %}


### PR DESCRIPTION
Google Analytics is currently hard-coded in the base template with no easy way to at least customize the `trackingId`.

With this PR this code is moved to another file that can be overridden by a child Bundle and a new parameter (`google_analytics_trackingId`) is created to allow the `trackingId` to be easily configured.