### PR TITLE
v1.21 - Removed deprecated config and moved it to .env

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,5 @@
+# Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
+TRUSTED_PROXIES=127.0.0.1,172.17.0.0/16,172.29.0.0/16,172.28.6.27,200.198.128.180,200.198.128.224
+
+# IPs allowed to access dev environment
+DEV_ALLOWED=127.0.0.0/8,172.17.0.0/16,172.29.0.0/16,172.28.0.0/16,10.124.0.0/16,10.127.9.0/24

--- a/.env.dist
+++ b/.env.dist
@@ -1,4 +1,4 @@
-# Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
+# Trusted proxies (https://symfony.com/doc/3.4/deployment/proxies.html#solution-settrustedproxies)
 TRUSTED_PROXIES=127.0.0.1,172.17.0.0/16,172.29.0.0/16,172.28.6.27,200.198.128.180,200.198.128.224
 
 # IPs allowed to access dev environment

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /.vagrant
 .idea
 /doc/site
+.env

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,6 @@ framework:
         engines: ['twig']
         #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
-    trusted_proxies: %trusted_proxies%
     session:         ~
     fragments:       ~
     http_method_override: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -13,11 +13,7 @@ parameters:
     database_password: logincidadao
     database_server_version: ~
 
-    # Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
-    trusted_proxies: []
-    # IPs allowed to access dev environment
-    dev_allowed: [ 127.0.0.0/8 ]
-    # IPs allowed to access monitoring endpoint
+    # IPs allowed to access monitoring endpoints
     allowed_monitors: [ 127.0.0.0/8 ]
 
     # Memcached server address

--- a/app/config/parameters.yml.vagrant
+++ b/app/config/parameters.yml.vagrant
@@ -7,11 +7,7 @@ parameters:
     database_password: ~
     database_server_version: ~
 
-    # Trusted proxies (http://symfony.com/doc/current/cookbook/request/load_balancer_reverse_proxy.html)
-    trusted_proxies: []
-    # IPs allowed to access dev environment
-    dev_allowed: [ 127.0.0.0/8 ]
-    # IPs allowed to access monitoring endpoint
+    # IPs allowed to access monitoring endpoints
     allowed_monitors: [ 127.0.0.0/8 ]
 
     memcached_host: 127.0.0.1

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -160,7 +160,7 @@ security:
         - { path: ^/api/v1/address/(cities|states|countries)/search, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
         - { path: ^/api/v1/public/lc_consultaCep2, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
         - { path: ^/api/v1/statistics, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
-        - { path: ^/api/v1/phone-verification/(update-status|average-delivery-time|not-delivered), role: IS_AUTHENTICATED_ANONYMOUSLY, ip: %allowed_monitors%, requires_channel: https }
+        - { path: ^/api/v1/phone-verification/(update-status|average-delivery-time|not-delivered), role: IS_AUTHENTICATED_ANONYMOUSLY, ips: "%allowed_monitors%", requires_channel: https }
         - { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY ], requires_channel: https }
 
         - { path: ^/oauth$, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
@@ -178,7 +178,7 @@ security:
         - { path: ^/connect/twitter$, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
         - { path: ^/connect/google$, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
 
-        - { path: ^/monitor/health, role: IS_AUTHENTICATED_ANONYMOUSLY, ip: %allowed_monitors%, requires_channel: https }
+        - { path: ^/monitor/health, role: IS_AUTHENTICATED_ANONYMOUSLY, ips: "%allowed_monitors%", requires_channel: https }
 
         - { path: ^/nelmio/csp/report$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/(contact|privacy|about|help|register), role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "php-http/httplug-bundle": "^1.11",
         "php-http/curl-client": "^1.7",
         "guzzlehttp/psr7": "^1.4",
-        "symfony/dotenv": "^4.2"
+        "symfony/dotenv": "^3|^4"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3",

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "predis/predis": "^1.1",
         "php-http/httplug-bundle": "^1.11",
         "php-http/curl-client": "^1.7",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4",
+        "symfony/dotenv": "^4.2"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6a97d76ca05f311821fd7e2a5d4010a",
+    "content-hash": "d81562914646af70e7880feff093a52a",
     "packages": [
         {
             "name": "beelab/recaptcha2-bundle",
@@ -6374,63 +6374,6 @@
             ],
             "abandoned": "symfony/webpack-encore-pack",
             "time": "2017-07-14T07:26:46+00:00"
-        },
-        {
-            "name": "symfony/dotenv",
-            "version": "v4.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dotenv.git",
-                "reference": "36e4e4750a88f52a5542bd8a54a947cb57039ece"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/36e4e4750a88f52a5542bd8a54a947cb57039ece",
-                "reference": "36e4e4750a88f52a5542bd8a54a947cb57039ece",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "symfony/process": "~3.4|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Dotenv\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Registers environment variables from a .env file",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "dotenv",
-                "env",
-                "environment"
-            ],
-            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/monolog-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3d13f6d9574e7b4a51bdb1626983a64",
+    "content-hash": "d6a97d76ca05f311821fd7e2a5d4010a",
     "packages": [
         {
             "name": "beelab/recaptcha2-bundle",
@@ -6374,6 +6374,63 @@
             ],
             "abandoned": "symfony/webpack-encore-pack",
             "time": "2017-07-14T07:26:46+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v4.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "36e4e4750a88f52a5542bd8a54a947cb57039ece"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/36e4e4750a88f52a5542bd8a54a947cb57039ece",
+                "reference": "36e4e4750a88f52a5542bd8a54a947cb57039ece",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "symfony/process": "~3.4|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/monolog-bundle",

--- a/web/app.php
+++ b/web/app.php
@@ -1,9 +1,13 @@
 <?php
 
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 use LoginCidadao\CoreBundle\Security\Compatibility\RamseyUuidFeatureSet;
 
 $loader = require_once __DIR__.'/../app/autoload.php';
+
+$dotenv = new Dotenv();
+$dotenv->load(__DIR__.'/../.env');
 
 $kernel = new AppKernel('prod', false);
 
@@ -11,6 +15,14 @@ $uuidFactory = new \Ramsey\Uuid\UuidFactory(new RamseyUuidFeatureSet());
 \Ramsey\Uuid\Uuid::setFactory($uuidFactory);
 $generator = new \Qandidate\Stack\UuidRequestIdGenerator();
 $stack = new \Qandidate\Stack\RequestId($kernel, $generator);
+
+try {
+    $trustedProxies = explode(',', getenv('TRUSTED_PROXIES'));
+    Request::setTrustedProxies($trustedProxies);
+} catch (Exception $ex) {
+    http_response_code(500);
+    exit('Invalid configuration');
+}
 
 $request = Request::createFromGlobals();
 


### PR DESCRIPTION
# Attention - ACTION NEEDED

Our Trusted Proxies and Dev Allowed IPs config got moved to the `.env` file. Please update your config accordingly.

Before you'd set it in the `parameters.yml` config file.

``` yaml
# app/config/parameters.yml
parameters:
    trusted_proxies:
        - 1.2.3.4/24
        - 10.20.30.40/24
    dev_allowed:
        - 20.30.40.0/16
```

Now it must be set either via Environment Variables or in the `.env` file.

The Env Variables expected are `TRUSTED_PROXIES` and `DEV_ALLOWED` and they expect comma-separated addresses. Example:

```
# .env
TRUSTED_PROXIES=1.2.3.4/24,10.20.30.40/24
DEV_ALLOWED=20.30.40.0/16
```

PROCERGS#833